### PR TITLE
MCView 0.2.41

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MCView
 Title: A Shiny App for Metacell Analysis
-Version: 0.2.40
+Version: 0.2.41
 Authors@R: 
     person(given = "Aviezer",
            family = "Lifshitz",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# MCView 0.2.41
+
+* Projects are now deployment-ready by default. An app.R file is automatically added during dataset import.
+* Unified the project and bundle structures - no need for a separate bundle creation step for basic deployment.
+* Added "Download data" button.
+* Keep the creation command in the config directory.
+* Added `copy_source_file` parameter to import_dataset to optionally copy the source h5ad file instead of creating a symlink.
+* Improved project directory handling with streamlined overwrite logic.
+* Added missing dataset name detection in import_dataset.
+
 # MCView 0.2.40 
 
 * Show metadata in markers heatmap tooltip.

--- a/R/app_modals.R
+++ b/R/app_modals.R
@@ -43,3 +43,41 @@ download_modal_reactives <- function(input, output, session, globals) {
         }
     )
 }
+
+download_data_modal_reactives <- function(input, output, session, globals) {
+    creation_text <- ""
+    if (fs::file_exists(command_file_path(project)) && !(!is.null(config$show_command) && !config$show_command) && !config$light_version) {
+        cmd_text <- readLines(command_file_path(project))
+        cmd_text <- paste0(cmd_text, collapse = "\n")
+        cmd_text <- paste0("```r\n", cmd_text, "\n```")
+        creation_text <- glue("The MCView app was created using the following commands:\n\n{cmd_text}")
+        creation_text <- markdown::markdownToHTML(text = creation_text, fragment.only = TRUE)
+        Encoding(creation_text) <- "UTF-8"
+        creation_text <- HTML(creation_text)
+    }
+
+    observeEvent(
+        input$download_data_modal,
+        showModal(modalDialog(
+            title = "Download data",
+            "To download the metacells anndata file, press the download button below:",
+            br(),
+            br(),
+            downloadButton("download_mc_data", glue("Download ({fs::file_info(source_metacells_file_path(project), follow=TRUE)$size})"), style = "align-items: center;"),
+            br(),
+            br(),
+            creation_text,
+            easyClose = TRUE
+        ))
+    )
+
+    output$download_mc_data <- downloadHandler(
+        filename = function() {
+            glue("{basename(project)}_metacells.h5ad")
+        },
+        content = function(file) {
+            fs::file_copy(source_metacells_file_path(project), file)
+            invisible(file)
+        }
+    )
+}

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -123,6 +123,7 @@ app_server <- function(input, output, session) {
     clipboard_reactives(dataset, input, output, session, metacell_types, cell_type_colors, gene_modules, globals)
 
     download_modal_reactives(input, output, session, globals)
+    download_data_modal_reactives(input, output, session, globals)
 
     help_reactives(input, output, session, globals)
 

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -129,6 +129,15 @@ app_ui <- function(request) {
                     no_outline = FALSE
                 ),
                 shinyWidgets::actionBttn(
+                    inputId = "download_data_modal",
+                    label = "Download data",
+                    icon = NULL,
+                    color = "default",
+                    size = "sm",
+                    block = FALSE,
+                    no_outline = FALSE
+                ),
+                shinyWidgets::actionBttn(
                     inputId = "download_modal",
                     label = "Run locally",
                     icon = NULL,

--- a/R/cell_types.R
+++ b/R/cell_types.R
@@ -29,7 +29,7 @@
 #'
 #' @export
 update_metacell_types <- function(project, dataset, metacell_types_file) {
-    verify_project_dir(project)
+    init_project_dir(project)
     verify_app_cache(project)
 
     prev_metacell_types <- load_shiny_data("metacell_types", dataset, project_cache_dir(project))
@@ -85,7 +85,7 @@ update_metacell_types <- function(project, dataset, metacell_types_file) {
 #'
 #' @export
 update_cell_type_colors <- function(project, dataset, cell_type_colors_file) {
-    verify_project_dir(project)
+    init_project_dir(project)
     verify_app_cache(project)
 
     cell_type_colors <- parse_cell_type_colors(cell_type_colors_file)

--- a/R/import_metacell1.R
+++ b/R/import_metacell1.R
@@ -87,7 +87,7 @@ import_dataset_metacell1 <- function(project,
     }
 
     verbose <- !is.null(getOption("MCView.verbose")) && getOption("MCView.verbose")
-    verify_project_dir(project, create = TRUE, ...)
+    init_project_dir(project, create = TRUE, ...)
 
     cli_alert_info("Importing {.field {dataset}}")
 

--- a/R/run_app.R
+++ b/R/run_app.R
@@ -23,7 +23,7 @@ run_app <- function(project,
                     host = NULL,
                     launch.browser = FALSE,
                     ...) {
-    project <- verify_project_dir(project)
+    project <- init_project_dir(project)
     verify_version(project)
     init_config(project = project)
     load_all_data(cache_dir = project_cache_dir(project))

--- a/R/utils_files.R
+++ b/R/utils_files.R
@@ -1,7 +1,52 @@
-check_metacell_types <- function(metacell_types) {
-    return(TRUE)
+command_file_path <- function(path) {
+    fs::path(path, "config", "IMPORT_COMMAND.R")
 }
 
-check_cell_type_colors <- function(cell_type_colors) {
-    return(TRUE)
+#' Save function call to a file
+#'
+#' This helper function captures the calling function's arguments and
+#' saves them to a specified file.
+#'
+#' @param command_file name or path of the file to save the command
+#' @param call_depth integer specifying how many levels up the call stack to capture (default is 1, which captures the direct caller)
+#' @param add_details logical specifying whether to add details about the user and time to the saved command
+#'
+#' @return invisibly returns the path to the saved file
+#'
+#' @examples
+#' \dontrun{
+#' # Inside another function:
+#' save_function_call()
+#' save_function_call("import.R")
+#' }
+#' @noRd
+save_function_call <- function(command_file = "IMPORT_COMMAND", call_depth = 1, add_details = TRUE, project = NULL) {
+    # Get the call from the specified depth in the call stack
+    parent_call <- sys.call(-call_depth)
+
+    # Convert to a string with a generous width to avoid unnecessary line breaks
+    call_string <- deparse(parent_call, width.cutoff = 500)
+
+    # Combine lines if it's a multi-line string
+    if (length(call_string) > 1) {
+        call_string <- paste(call_string, collapse = "\n")
+    }
+
+    call_string <- paste0("setwd(\"", getwd(), "\")\n", call_string)
+    call_string <- paste0("library(MCView)\n\n", call_string)
+
+    if (add_details) {
+        call_string <- paste0(call_string, "\n\n# Command was run by ", Sys.info()["user"], " at ", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "\n# MCView version: ", utils::packageVersion("MCView"))
+        if (!is.null(project) && fs::file_exists(project_metacells_algorithm_file(project))) {
+            mc_version <- readLines(project_metacells_algorithm_file(project))
+            call_string <- paste0(call_string, "\n# Metacells algorithm version: ", mc_version)
+        }
+    }
+
+    if (fs::file_exists(command_file)) {
+        fs::file_delete(command_file)
+    }
+
+    writeLines(call_string, command_file)
+    return(invisible(command_file))
 }

--- a/R/utils_gene_modules.R
+++ b/R/utils_gene_modules.R
@@ -20,7 +20,7 @@
 #'
 #' @export
 update_gene_modules <- function(project, dataset, gene_modules_file) {
-    verify_project_dir(project)
+    init_project_dir(project)
     verify_app_cache(project)
 
     gene_modules <- parse_gene_modules_file(gene_modules_file)

--- a/R/utils_heatmap.R
+++ b/R/utils_heatmap.R
@@ -71,6 +71,7 @@ heatmap_sidebar <- function(id, ..., show_fitted_filter = FALSE) {
         include_noisy_ui <- NULL
     } else {
         max_gene_num_ui <- numericInput(ns("max_gene_num"), "Maximal number of genes", value = 100)
+        highlight_genes_ui <- shinyWidgets::actionGroupButtons(ns("highlight_genes"), labels = "Highlight selected genes", size = "sm")
         remove_genes_ui <- shinyWidgets::actionGroupButtons(ns("remove_genes"), labels = "Remove selected genes", size = "sm")
         add_genes_ui <- uiOutput(ns("add_genes_ui"))
         update_genes_ui <- shinyWidgets::actionGroupButtons(ns("update_genes"), labels = "Update genes", size = "sm")
@@ -136,6 +137,7 @@ heatmap_sidebar <- function(id, ..., show_fitted_filter = FALSE) {
             size = 30,
             selectize = FALSE
         ),
+        highlight_genes_ui,
         remove_genes_ui,
         update_genes_ui,
         show_only_fitted_ui,
@@ -257,8 +259,6 @@ heatmap_matrix_reactives <- function(ns, input, output, session, dataset, metace
 
         markers(new_markers)
     })
-
-
 
     observeEvent(input$remove_genes, {
         req(markers())

--- a/inst/app.R
+++ b/inst/app.R
@@ -1,7 +1,14 @@
 # Launch the ShinyApp
 
 options("golem.app.prod" = TRUE)
-if (dir.exists("code")){
+if (dir.exists("code")) {
     pkgload::load_all("code", export_all = FALSE)
 }
-MCView::run_app(project = "project")
+
+if (dir.exists("project")) { # here for backward compatibility
+    MCView::run_app("project")
+} else {
+    MCView::run_app(getwd())
+}
+
+

--- a/man/import_dataset.Rd
+++ b/man/import_dataset.Rd
@@ -37,6 +37,7 @@ import_dataset(
   layout = NULL,
   default_graph = NULL,
   overwrite = TRUE,
+  copy_source_file = FALSE,
   ...
 )
 }
@@ -140,6 +141,8 @@ log fraction (mc_fp) above this this value}
 
 \item{overwrite}{if a dataset with the same name already exists, overwrite it. Otherwise, an error would be thrown.}
 
+\item{copy_source_file}{if TRUE, copy the source file to the project cache directory. If FALSE, create a symbolic link to the source file.}
+
 \item{...}{
   Arguments passed on to \code{\link[=create_project]{create_project}}
   \describe{
@@ -178,7 +181,6 @@ download.file(
     "raw/PBMC_processed.tar.gz"
 )
 untar("raw/PBMC_processed.tar.gz", exdir = "raw")
-create_project("PBMC")
 import_dataset("PBMC", "PBMC163k", "raw/metacells.h5ad")
 }
 

--- a/vignettes/Architecture.Rmd
+++ b/vignettes/Architecture.Rmd
@@ -150,27 +150,61 @@ Running the app can be done by running:
 ```{r, eval=FALSE}
 MCView::run_app(project = "/path/to/my/project")
 ```
+
+
 ## Deployment
 
-__MCView__ can generate a 'deployment ready' version of the app by running: 
+Starting from version 0.2.41, MCView projects are deployment-ready by default. When you import a dataset using `import_dataset()`, an `app.R` file is automatically added to the project directory. This means you can simply copy the entire project directory to any Shiny server for deployment.
 
-```{r, eval=FALSE}
-MCView::create_bundle(project = "/path/to/my/project", path = "/path/to/the/bundle", name = "my_project")
+The structure of a deployment-ready MCView project looks like this:
+
+```
+my_project/
+├── app.R
+├── config/
+│   ├── about.Rmd
+│   ├── config.yaml
+│   └── help.yaml
+└── cache/
+    ├── dataset1/
+    └── dataset2/
 ```
 
-This would create a minimal shiny app in "/path/to/the/bundle/my_project" directory which would contain:
+To deploy the app, you can simply:
 
-1. app.R file. 
-2. project config and cache. 
-
-> Note: The bundle would use use the installed version of MCView in server. If you want to create a 'self-contained' bundle that would include MCView code as well, set `self_contained=TRUE`. 
-
-The bundle can then be deployed in shiny-server by running: 
+1. Copy the entire project directory to your Shiny server
+2. For shinyapps.io, run:
 
 ```{r, eval=FALSE}
-rsconnect::deployApp(appDir = "/path/to/the/bundle/my_project")
+rsconnect::deployApp(appDir = "my_project")
 ```
 
-or any other environment that supports serving shiny apps. 
+For backward compatibility, you can still create a separate bundle using:
 
-Note that when deploying to these services make sure you have the __MCView__ package installed. 
+```{r, eval=FALSE}
+MCView::create_bundle(project = "my_project", path = getwd(), name = "my_project_bundle")
+```
+
+However, this is no longer necessary as the project directory itself is already deployment-ready.
+
+Note: When deployed, the app will use the installed version of the MCView package on the server. If you want to ensure consistent behavior regardless of package updates, you can create a self-contained bundle that includes the MCView code:
+
+```{r, eval=FALSE}
+MCView::create_bundle(
+    project = "my_project",
+    path = getwd(),
+    name = "my_project_bundle",
+    self_contained = TRUE
+)
+```
+
+I you need to create a light version of MCView for deployment on a server with limited resources, you can use the `light_version=TRUE` argument:
+
+```{r, eval=FALSE}
+MCView::create_bundle(
+    project = "my_project",
+    path = getwd(),
+    name = "my_project_bundle",
+    light_version = TRUE
+)
+```

--- a/vignettes/MCView.Rmd
+++ b/vignettes/MCView.Rmd
@@ -16,11 +16,13 @@ knitr::opts_chunk$set(
 
 ## Setup
 
-We would start by downloading a PBMC dataset that was pre-processed using the `metacells` python package. 
+First, let's load the MCView package:
 
 ```{r setup, eval = FALSE}
 library(MCView)
 ```
+
+For this tutorial, we'll use a PBMC dataset that was pre-processed using the `metacells` python package.
 
 ```{r download, eval=FALSE}
 dir.create("raw")
@@ -28,96 +30,76 @@ download.file("http://www.wisdom.weizmann.ac.il/~atanay/metac_data/PBMC_processe
 untar("raw/PBMC_processed.tar.gz", exdir = "raw")
 ```
 
-The above commands end result are two files named "raw/pbmc_metacells.h5ad" and "raw/cluster-colors.csv" which we would import to __MCView__ in the next steps. 
+This gives us two files: "raw/metacells.h5ad" (the metacell data) and "raw/cluster-colors.csv" (color assignments for cell types).
 
-## Create a project
+## Import Dataset
 
-> You can either start by creating a new project, or skip this step and import the dataset (a project would be created automatically).
-
-The first step in running __MCView__ is generating a project directory structure: 
-
-```{r, eval=FALSE}
-create_project("PBMC", title = "PBMC")
-```
-
-A text editor would be opened with `PBMC/config/config.yaml` file:
-
-```yaml
-title: PBMC
-tabs: ["QC", "Manifold", "Genes", "Markers", "Gene modules", "Diff. Expression", "Cell types","Annotate", "About"] # which tabs to show
-help: false # set to true to show introjs help on start
-# selected_gene1: Foxc1 # Default selected gene1
-# selected_gene2: Twist1 # Default selected gene2
-selected_mc1: 1 # Default selected metacell1 
-selected_mc2: 2 # Default selected metacell2
-```
-
-The configuration file was generated using `create_project` parameters, but we can edit them if we want, or add parameters per dataset, see the [architecture](https://tanaylab.github.io/MCView/articles/Architecture.html) vignette for a full description of the config parameters. 
-
-
-## Import 
-
-Next, we would import the PBMC dataset to the project we created. A project can contain multiple dataset, and switching between them can be done from the right sidebar. 
-
-This would pre-process the metacell dataset in order to view it in the shiny app: 
+The most common way to start with MCView is to directly import your dataset:
 
 ```{r, eval=FALSE}
 import_dataset(
-    project = "PBMC",
+    project = "PBMC", # This will create the project if it doesn't exist
     dataset = "PBMC",
     anndata_file = "raw/metacells.h5ad",
     cell_type_field = "type"
 )
 ```
 
-The most important field is the `anndata` field which points to the h5ad file we downloaded. 
+This single command:
+1. Creates a project directory structure if it doesn't exist
+2. Pre-processes the metacell dataset for viewing in the app
+3. Adds an `app.R` file, making the project deployment-ready
 
-You can see that we also specified a field in the `h5ad` object that has pre-computed cluster assignments per metacell at the 'type' field. 
+The `anndata_file` points to the h5ad file we downloaded, and `cell_type_field` specifies the field in the h5ad object that contains pre-computed cluster assignments.
 
-Note that the import part might take a few minutes, depending (mostly) on the number of metacells. If you see that it takes too long - set `calc_gg_cor` to `FALSE` in order to skip calculating correlation between all genes. This would save significant amount of import time but would make this feature unavailable in the app. 
+> **Note**: Import may take a few minutes depending on the number of metacells. If it's too slow, set `calc_gg_cor = FALSE` to skip calculating gene correlations. This saves significant import time but makes this feature unavailable in the app.
 
-In addition, some features would only be available if you ran `compute_for_mcview` in the `metacells` python package, so try to remember running it before importing to __MCView__.  
+> **Tip**: Run `compute_for_mcview` in the `metacells` python package before importing to enable all MCView features.
 
-__MCView__ supports also importing datasets from the old R `metacell` package, see `import_dataset_metacell1` for details.
+MCView also supports importing datasets from the old R `metacell` package with `import_dataset_metacell1`.
 
 ## Run the app
+
+Once import is complete, you can run the app:
 
 ```{r, eval=FALSE}
 run_app(project = "PBMC", launch.browser = TRUE)
 ```
 
-A browser window would be opened with the app. 
-
-You can also specify the port or host, or do not launch the browser window, e.g.: 
+This opens a browser window with the app. You can customize the port, host, and browser launch:
 
 ```{r, eval=FALSE}
 run_app(project = "PBMC", port = 5555, host = "127.0.0.1", launch.browser = FALSE)
 ```
 
+If you're already in the project directory, simply run:
+
+```{r, eval=FALSE}
+run_app(launch.browser = TRUE)
+```
+
 ## Update annotations
 
-After working a bit on the initial metacell model, we would usually want to update the default dataset annotations with the ones we created using __MCView__. This can be done by:
+After working with the initial metacell model, you might want to update the annotations:
 
-1. Pressing the "export" button in the upper left of "Annotate" screen and saving the file. 
-2. Running: 
-
-```{r, eval=FALSE}
-update_metacell_types("PBMC", "PBMC163k", "/path/to/metacell_types_file")
-```
-
-Where "/path/to/metacell_types_file" is the path of the exported file. 
-
-You can now rerun the app and the types/colors would be updated. 
-
-If you only want to update the cell type colors you can run: 
+1. Export your changes by pressing the "export" button in the upper left of the "Annotate" screen 
+2. Update the annotations with:
 
 ```{r, eval=FALSE}
-update_cell_type_colors("PBMC", "PBMC163k", "/path/to/cell_type_colors_file")
+update_metacell_types("PBMC", "PBMC", "/path/to/metacell_types_file")
 ```
 
-## Metadata
+Where "/path/to/metacell_types_file" is the path to your exported file.
 
-You can load metadata fields for each metacell using the `metadata` parameter in `import_dataset` command:
+To only update cell type colors:
+
+```{r, eval=FALSE}
+update_cell_type_colors("PBMC", "PBMC", "/path/to/cell_type_colors_file")
+```
+
+## Working with metadata
+
+You can add metadata for each metacell during import:
 
 ```{r, eval=FALSE}
 import_dataset(
@@ -128,45 +110,84 @@ import_dataset(
 )
 ```
 
-The format is a data frame (or a delimited filename) with a column named `metacell` and the annotation fields. The metadata fields can be either numeric or categorical. 
+The metadata should be a data frame (or file) with a column named `metacell` and additional annotation fields, which can be numeric or categorical.
 
-You can use the `metadata_colors` parameter to set the breaks and colors for each numerical metadata field, and color for each category for categorical fields. 
+Use `metadata_colors` to customize colors for each field.
 
-If you want to change the metadata fields or colors after the import, you can use the `update_metadata` and `update_metadata_colors` functions:
+To update metadata after import:
 
 ```{r, eval=FALSE}
 update_metadata(
     project = "PBMC",
-    dataset = "PBMC163k",
+    dataset = "PBMC",
     metadata = "new_metadata.csv"
 )
+
 update_metadata_colors(
     project = "PBMC",
-    dataset = "PBMC163k",
+    dataset = "PBMC",
     metadata_colors = new_metadata_colors
 )
 ```
 
-You can generate metadata per metacell from cell metadata using the `cell_metadata_to_metacell` and `cell_metadata_to_metacell_from_h5ad` functions. 
+You can generate metacell metadata from cell metadata using `cell_metadata_to_metacell` or `cell_metadata_to_metacell_from_h5ad`.
 
-## Deploy
+## Deploy your app
 
-Create a deployment ready bundle by running: 
+MCView projects are deployment-ready by default. The `app.R` file added during import means you can deploy your app by simply copying the entire project directory to a Shiny server.
+
+### Direct Deployment
+
+Deploy to [shinyapps.io](https://docs.rstudio.com/shinyapps.io/getting-started.html#deploying-applications):
 
 ```{r, eval=FALSE}
-create_bundle(project = "PBMC", path = getwd(), name = "PBMC_bundle")
+rsconnect::deployApp(appDir = "PBMC")
 ```
 
-You can then upload the bundle to [shinyapps.io](https://docs.rstudio.com/shinyapps.io/getting-started.html#deploying-applications) by running: 
+Or deploy to any Shiny server by copying the "PBMC" directory to the server.
+
+### Advanced Deployment (Optional)
+
+For additional customization (such as including MCView code in your bundle):
 
 ```{r, eval=FALSE}
+create_bundle(
+    project = "PBMC",
+    path = getwd(),
+    name = "PBMC_bundle",
+    self_contained = TRUE # Includes MCView code in the bundle
+)
+
+# Then deploy
 rsconnect::deployApp(appDir = file.path(getwd(), "PBMC_bundle"))
 ```
 
-Or to any shiny-server hosting service by uploading the "PBMC_bundle" directory to the service. 
+> **Note**: MCView keeps the metacell matrix in memory and requires around 1GB of RAM for small datasets like PBMC, and up to 2-4GB for larger datasets. Adjust your hosting service settings accordingly.
 
-> Note that you might need to set your hosting service to allow higher memory than the default - __MCView__ keeps the metacell matrix in-memory and therefore needs around 1GB of RAM for small datasets such as PBMC, but up to 2-4GB for large datasets such as MOCA. 
+## Advanced: Manual project creation
+
+If you want to customize your project configuration before importing data, you can manually create a project first:
+
+```{r, eval=FALSE}
+create_project("PBMC", title = "PBMC")
+```
+
+This opens a text editor with `PBMC/config/config.yaml`:
+
+```yaml
+title: PBMC
+tabs: ["QC", "Manifold", "Genes", "Markers", "Gene modules", "Diff. Expression", "Cell types","Annotate", "About"]
+help: false
+# selected_gene1: Foxc1
+# selected_gene2: Twist1
+selected_mc1: 1
+selected_mc2: 2
+```
+
+After editing, proceed with `import_dataset` as shown earlier.
+
+See the [architecture](https://tanaylab.github.io/MCView/articles/Architecture.html) vignette for a complete description of configuration parameters.
 
 ## Docker 
 
-See the [docker](https://tanaylab.github.io/MCView/articles/Docker.html) vignette for instructions of using the docker image. 
+See the [docker](https://tanaylab.github.io/MCView/articles/Docker.html) vignette for instructions on using the Docker image.


### PR DESCRIPTION
* Projects are now deployment-ready by default. An app.R file is automatically added during dataset import.
* Unified the project and bundle structures - no need for a separate bundle creation step for basic deployment.
* Added "Download data" button.
* Keep the creation command in the config directory.
* Added `copy_source_file` parameter to import_dataset to optionally copy the source h5ad file instead of creating a symlink.
* Improved project directory handling with streamlined overwrite logic.
* Added missing dataset name detection in import_dataset.