### PR TITLE
Gene projections in genes tab bugfix

### DIFF
--- a/R/plot_mc2d_proj.R
+++ b/R/plot_mc2d_proj.R
@@ -5,7 +5,7 @@
 #' @noRd
 mc2d_plot_gene_ggp <- function(dataset, gene, point_size = initial_proj_point_size(dataset), min_d = min_edge_length(dataset), stroke = initial_proj_stroke(dataset), graph_color = "black", graph_width = 0.1, id = NULL, max_lfp = NULL, min_lfp = NULL, max_expr = NULL, min_expr = NULL, stat = "expression", atlas = FALSE, gene_name = NULL, graph_name = NULL, mc2d = NULL, selected_cell_types = NULL, metacell_types = NULL) {
     mc2d <- mc2d %||% get_mc_data(dataset, "mc2d", atlas = atlas)
-    metacell_types <- get_mc_data(dataset, "metacell_types", atlas = atlas)
+    metacell_types <- metacell_types %||% get_mc_data(dataset, "metacell_types", atlas = atlas)
     min_lfp <- min_lfp %||% -3
     max_lfp <- max_lfp %||% 3
     if (length(gene) > 1) {


### PR DESCRIPTION
  After loading metacell annotations from file, the Genes -> Gene projections plot could become effectively empty when Color by =
  Scatter Axis (points disappear, only graph edges remain), while Color by = Cell type still worked.

  Reproduction

  1. Open MCView.
  2. Load annotations from file in the Annotate workflow.
  3. Go to Genes -> Gene projections.
  4. Set Color by = Scatter Axis (x or y).
  5. Plot appears empty
  6. Switch to Cell type and plot looks normal.

  Root cause
 ` mc2d_plot_gene_ggp()` always reloaded metacell_types from cached dataset data, even when updated reactive annotations were passed in
  from the UI.
  So after annotation upload, gene/scatter-axis rendering used stale metacell type assignments, causing filtering mismatches and
  dropping plotted points.

  Fix
  Use passed metacell_types when available, and only fallback to cached data when missing:

  - metacell_types <- metacell_types %||% get_mc_data(...)

  This preserves cache fallback but prevents stale cache from overriding in-session annotation updates.
