### PR TITLE
Migrate serialization from qs to qs2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MCView
 Title: A Shiny App for Metacell Analysis
-Version: 0.2.53
+Version: 0.2.54
 Authors@R: 
     person(given = "Aviezer",
            family = "Lifshitz",
@@ -50,6 +50,7 @@ Imports:
     promises,
     purrr,
     qs,
+    qs2,
     rclipboard,
     rlang,
     rmarkdown,
@@ -89,7 +90,8 @@ Suggests:
     profvis
 VignetteBuilder: 
     knitr
-Remotes: 
+Remotes:
+    qsbase/qs,
     tanaylab/tgutil,
     tanaylab/metacell
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# MCView 0.2.54
+
+* Switched serialization from `qs` to `qs2` (`qs` was removed from CRAN). New cache files are saved in `.qs2` format. Existing projects with `.qs` cache files are still supported via the legacy `qs` package (installed from GitHub).
+
 # MCView 0.2.53
 
 * Fix: stroke was not working in the atlas tab.

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -89,9 +89,16 @@ update_metadata_colors <- function(project,
 
     new_metadata_colors <- parse_metadata_colors(metadata_colors, metadata)
 
-    prev_colors_file <- fs::path(cache_dir, dataset, "metadata_colors.qs")
-    if (fs::file_exists(prev_colors_file) && !overwrite) {
-        metadata_colors <- qs::qread(prev_colors_file)
+    prev_colors_file_qs2 <- fs::path(cache_dir, dataset, "metadata_colors.qs2")
+    prev_colors_file_qs <- fs::path(cache_dir, dataset, "metadata_colors.qs")
+    if (!overwrite && fs::file_exists(prev_colors_file_qs2)) {
+        metadata_colors <- qs2::qs_read(prev_colors_file_qs2)
+        for (f in names(metadata_colors)) {
+            metadata_colors[[f]] <- NULL
+        }
+        metadata_colors <- c(metadata_colors, new_metadata_colors)
+    } else if (!overwrite && fs::file_exists(prev_colors_file_qs)) {
+        metadata_colors <- qs::qread(prev_colors_file_qs)
         for (f in names(metadata_colors)) {
             metadata_colors[[f]] <- NULL
         }

--- a/R/utils_cache.R
+++ b/R/utils_cache.R
@@ -1,4 +1,4 @@
-serialize_shiny_data <- function(object, name, dataset, cache_dir, df2mat = FALSE, preset = "fast", flat = FALSE, ...) {
+serialize_shiny_data <- function(object, name, dataset, cache_dir, df2mat = FALSE, flat = FALSE, ...) {
     dataset_dir <- fs::path(cache_dir, dataset)
 
     if (!fs::dir_exists(dataset_dir)) {
@@ -12,7 +12,7 @@ serialize_shiny_data <- function(object, name, dataset, cache_dir, df2mat = FALS
     if (flat) {
         fwrite(object, fs::path(dataset_dir, glue("{name}.tsv")), sep = "\t")
     } else {
-        qs::qsave(object, fs::path(dataset_dir, glue("{name}.qs")), preset = preset, ...)
+        qs2::qs_save(object, fs::path(dataset_dir, glue("{name}.qs2")), ...)
     }
 
     cli_alert_success_verbose("saved {.field {name}}")
@@ -32,7 +32,15 @@ load_shiny_data <- function(name, dataset, cache_dir, atlas = FALSE) {
             object$metacell <- as.character(object$metacell)
         }
     } else {
-        object <- qs::qread(fs::path(cache_dir, glue("{name}.qs")))
+        qs2_file <- fs::path(cache_dir, glue("{name}.qs2"))
+        qs_file <- fs::path(cache_dir, glue("{name}.qs"))
+        if (fs::file_exists(qs2_file)) {
+            object <- qs2::qs_read(qs2_file)
+        } else if (fs::file_exists(qs_file)) {
+            object <- qs::qread(qs_file)
+        } else {
+            cli_abort("Cannot find {.file {name}} in {.file {cache_dir}} (looked for .qs2 and .qs files)")
+        }
     }
 
     if (is.data.frame(object) && rlang::has_name(object, "__rowname__")) {
@@ -47,7 +55,7 @@ load_shiny_data <- function(name, dataset, cache_dir, atlas = FALSE) {
 load_all_mc_data_atlas <- function(dataset, cache_dir) {
     atlas_dir <- fs::path(cache_dir, dataset, "atlas")
     if (fs::dir_exists(atlas_dir)) {
-        files <- list.files(atlas_dir, pattern = "*\\.(qs|tsv|csv)")
+        files <- list.files(atlas_dir, pattern = "*\\.(qs2|qs|tsv|csv)")
 
         if (is.null(mc_data[[dataset]])) {
             mc_data[[dataset]] <<- list()
@@ -59,7 +67,7 @@ load_all_mc_data_atlas <- function(dataset, cache_dir) {
 
         for (fn in files) {
             var_name <- basename(fn) %>%
-                sub("\\.qs$", "", .) %>%
+                sub("\\.(qs2|qs)$", "", .) %>%
                 sub("\\.tsv$", "", .)
             obj <- load_shiny_data(var_name, dataset, cache_dir, atlas = TRUE)
 
@@ -74,7 +82,7 @@ load_all_mc_data <- function(dataset, cache_dir) {
         load_all_mc_data_atlas(dataset, cache_dir)
     }
 
-    files <- list.files(fs::path(cache_dir, dataset), pattern = "*\\.(qs|tsv|csv)")
+    files <- list.files(fs::path(cache_dir, dataset), pattern = "*\\.(qs2|qs|tsv|csv)")
 
     if (is.null(mc_data[[dataset]])) {
         mc_data[[dataset]] <<- list()
@@ -82,7 +90,7 @@ load_all_mc_data <- function(dataset, cache_dir) {
 
     for (fn in files) {
         var_name <- basename(fn) %>%
-            sub("\\.qs$", "", .) %>%
+            sub("\\.(qs2|qs)$", "", .) %>%
             sub("\\.tsv$", "", .)
         obj <- load_shiny_data(var_name, dataset, cache_dir)
 
@@ -90,7 +98,7 @@ load_all_mc_data <- function(dataset, cache_dir) {
     }
 }
 
-verify_app_cache <- function(project, required_files = c("mc_mat.qs", "mc_sum.qs", "mc2d.qs", "metacell_types.tsv", "cell_type_colors.tsv"), datasets = NULL) {
+verify_app_cache <- function(project, required_files = c("mc_mat", "mc_sum", "mc2d", "metacell_types", "cell_type_colors"), datasets = NULL) {
     cache_dir <- project_cache_dir(project)
     if (is.null(datasets)) {
         datasets <- dataset_ls(project)
@@ -99,7 +107,9 @@ verify_app_cache <- function(project, required_files = c("mc_mat.qs", "mc_sum.qs
     for (dataset in datasets) {
         dataset_dir <- fs::path(cache_dir, dataset)
         for (file in required_files) {
-            if (!fs::file_exists(fs::path(dataset_dir, file))) {
+            extensions <- c(".qs2", ".qs", ".tsv", ".csv")
+            found <- any(purrr::map_lgl(extensions, ~ fs::file_exists(fs::path(dataset_dir, paste0(file, .x)))))
+            if (!found) {
                 cli_abort("The file {.file {file}} is missing in {.file {dataset_dir}}. Did you forget to import?")
             }
         }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -40,12 +40,12 @@ test_cache_file_exists <- function(file, project_dir, dataset) {
 test_dataset <- function(project_dir,
                          dataset,
                          required_files = c(
-                             "mc_mat.qs",
-                             "mc_sum.qs",
-                             "mc2d.qs",
+                             "mc_mat.qs2",
+                             "mc_sum.qs2",
+                             "mc2d.qs2",
                              "metacell_types.tsv",
                              "cell_type_colors.tsv",
-                             "marker_genes.qs"
+                             "marker_genes.qs2"
                          )) {
     dataset_dir <- fs::path(project_dir, "cache", dataset)
     expect_true(fs::dir_exists(project_dir))

--- a/tests/testthat/test-2_import.R
+++ b/tests/testthat/test-2_import.R
@@ -86,12 +86,12 @@ test_that("import_dataset works with calc_gg_cor=TRUE", {
         project_dir,
         "PBMC163k_gg_cor",
         required_files = c(
-            "mc_mat.qs",
-            "mc_sum.qs",
-            "mc2d.qs",
+            "mc_mat.qs2",
+            "mc_sum.qs2",
+            "mc2d.qs2",
             "metacell_types.tsv",
             "cell_type_colors.tsv",
-            "gg_mc_top_cor.qs"
+            "gg_mc_top_cor.qs2"
         )
     )
     withr::defer(unlink(fs::path(project_dir, "cache", "PBMC163k_ctf_ctcf")))

--- a/tests/testthat/test-3_metadata.R
+++ b/tests/testthat/test-3_metadata.R
@@ -272,7 +272,7 @@ test_that("import_dataset works with metadata colors", {
     saved_md <- tgutil::fread(fs::path(project_dir, "cache", dataset, "metadata.tsv")) %>% tibble::as_tibble()
     expect_equivalent(metadata_df, saved_md)
 
-    saved_md_colors <- qs::qread(fs::path(project_dir, "cache", dataset, "metadata_colors.qs"))
+    saved_md_colors <- qs2::qs_read(fs::path(project_dir, "cache", dataset, "metadata_colors.qs2"))
     expect_equivalent(metadata_colors, saved_md_colors)
 
     withr::defer(unlink(fs::path(project_dir, "cache", dataset)))
@@ -358,7 +358,7 @@ test_that("import_dataset works with metadata colors without breaks", {
     saved_md <- tgutil::fread(fs::path(project_dir, "cache", dataset, "metadata.tsv")) %>% tibble::as_tibble()
     expect_equivalent(metadata_df, saved_md)
 
-    saved_md_colors <- qs::qread(fs::path(project_dir, "cache", dataset, "metadata_colors.qs"))
+    saved_md_colors <- qs2::qs_read(fs::path(project_dir, "cache", dataset, "metadata_colors.qs2"))
     expect_equivalent(metadata_colors, saved_md_colors)
 
     withr::defer(unlink(fs::path(project_dir, "cache", dataset)))
@@ -589,7 +589,7 @@ test_that("update_metadata_colors work", {
         overwrite = FALSE
     )
 
-    saved_md_colors <- qs::qread(fs::path(project_dir, "cache", dataset, "metadata_colors.qs"))
+    saved_md_colors <- qs2::qs_read(fs::path(project_dir, "cache", dataset, "metadata_colors.qs2"))
     expect_equivalent(metadata_colors_modified, saved_md_colors)
 
     withr::defer(unlink(fs::path(project_dir, "cache", dataset)))
@@ -638,7 +638,7 @@ test_that("update_metadata_colors work with overwrite = TRUE", {
         overwrite = TRUE
     )
 
-    saved_md_colors <- qs::qread(fs::path(project_dir, "cache", dataset, "metadata_colors.qs"))
+    saved_md_colors <- qs2::qs_read(fs::path(project_dir, "cache", dataset, "metadata_colors.qs2"))
     expect_equivalent(metadata_colors_modified, saved_md_colors)
 
     withr::defer(unlink(fs::path(project_dir, "cache", dataset)))


### PR DESCRIPTION
## Summary

- The `qs` package was removed from CRAN. This PR switches MCView to use `qs2` for writing new cache files (`.qs2` format).
- Existing projects with `.qs` cache files continue to work: the reading logic tries `.qs2` first, then falls back to `qs::qread()` for legacy `.qs` files.
- The `qs` package is retained as a dependency installed from GitHub (`qsbase/qs`) for backward compatibility.
- `verify_app_cache` now checks for files by base name across all supported extensions (`.qs2`, `.qs`, `.tsv`, `.csv`).
- Bumps version to 0.2.54.

## Test plan
- [ ] Verify new imports create `.qs2` cache files
- [ ] Verify existing projects with `.qs` cache files still load correctly
- [ ] Run existing test suite (`testthat`)